### PR TITLE
crash after long copilot suggestion

### DIFF
--- a/lua/plugins/_workaround.lua
+++ b/lua/plugins/_workaround.lua
@@ -1,9 +1,0 @@
-return {
-	-- ISSUE: https://github.com/Saghen/blink.cmp/issues/1727#issuecomment-2867452782
-	{
-		"saghen/blink.cmp",
-		opts = {
-			fuzzy = { implementation = "lua" },
-		},
-	},
-}


### PR DESCRIPTION
this is a branch to figure out when & and what will make the copilot stop crashing

reproduce crash on turnip

- checkout this branch in `./config/nvim`
- checkout `turnip-copilot-crash-test` in `python-architecture`
- fire up nvim and follow the instructions in `test_sync.py`

once some combination of updates causes the crash to go away w/o the workaround merge to close #3 
